### PR TITLE
feat: Advance IIP-3 to Proposed status following v1.4.1-rc release

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ You may find more information about the IIP Process in [IIP-1](./iips/IIP-0001/i
 
 ![image](iips/IIP-0001/process.svg)
 
-| #  | Title                                                    | Description                                                                                                   | Type      | Layer     | Status |
-|----|----------------------------------------------------------|---------------------------------------------------------------------------------------------------------------|-----------|-----------|--------|
-| 1  | [IIP Process](iips/IIP-0001/iip-0001.md)                 | Purpose and guidelines of the contribution framework                                                          | Process   | -         | Active |
-| 2  | [Starfish Consensus Protocol](iips/IIP-0002/iip-0002.md) | A DAG-based consensus protocol improving liveness and efficiency                                              | Standards | Core      | Draft  |
-| 3  | [Sequencer Improvements](iips/IIP-0003/iip-0003.md)      | Improved sequencing algorithm for reducing the number of transaction cancellations                            | Standards | Core      | Draft  |
-| 5  | [Move View Functions](iips/IIP-0005/iip-0005.md)         | A standardized interface for application-specific queries to on-chain state                                   | Standards | Interface | Draft  |
+| \# | Title                                                    | Description                                                                        | Type      | Layer     | Status   |
+|----|----------------------------------------------------------|------------------------------------------------------------------------------------|-----------|-----------|----------|
+| 1  | [IIP Process](iips/IIP-0001/iip-0001.md)                 | Purpose and guidelines of the contribution framework                               | Process   | \-        | Active   |
+| 2  | [Starfish Consensus Protocol](iips/IIP-0002/iip-0002.md) | A DAG-based consensus protocol improving liveness and efficiency                   | Standards | Core      | Draft    |
+| 3  | [Sequencer Improvements](iips/IIP-0003/iip-0003.md)      | Improved sequencing algorithm for reducing the number of transaction cancellations | Standards | Core      | Proposed |
+| 5  | [Move View Functions](iips/IIP-0005/iip-0005.md)         | A standardized interface for application-specific queries to on-chain state        | Standards | Interface | Draft    |
 
 
 ## Need help?

--- a/iips/IIP-0003/iip-0003.md
+++ b/iips/IIP-0003/iip-0003.md
@@ -4,7 +4,7 @@ title: Sequencer Improvements
 description: A sequencing algorithm that assigns the earliest available execution slot to transactions.
 author: Can Umut Ileri (@cuileri) and Andrew Cullen (@cyberphysic4l)
 discussions-to: https://github.com/iotaledger/IIPs/discussions/14
-status: Draft
+status: Proposed
 type: Standards Track
 layer: Core
 created: 2025-04-23


### PR DESCRIPTION
[[Testnet] v1.4.1-rc](https://github.com/iotaledger/iota/releases/tag/v1.4.1-rc) release activated [IIP-3](https://github.com/iotaledger/IIPs/blob/main/iips/IIP-0003/iip-0003.md) on the network at Epoch 262.