### PR TITLE
chore: update status of IIP-2 (Starfish) to Active

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You may find more information about the IIP Process in [IIP-1](./iips/IIP-0001/i
 
 ## List of IIPs
 
- - Last updated: 2026-03-20
+ - Last updated: 2026-04-27
  - The _Status_ of a IIP reflects its current state with respect to its progression to being supported on the IOTA Mainnet.
    - `Draft` IIPs are work in progress. They may or may not have a working implementation on a testnet.
    - `Proposed` IIPs are demonstrated to have a working implementation on the IOTA Devnet or Testnet.
@@ -38,7 +38,7 @@ You may find more information about the IIP Process in [IIP-1](./iips/IIP-0001/i
 | \# | Title                                                    | Description                                                                        | Type      | Layer     | Status   |
 |----|----------------------------------------------------------|------------------------------------------------------------------------------------|-----------|-----------|----------|
 | 1  | [IIP Process](iips/IIP-0001/iip-0001.md)                 | Purpose and guidelines of the contribution framework                               | Process   | \-        | Active   |
-| 2  | [Starfish Consensus Protocol](iips/IIP-0002/iip-0002.md) | A DAG-based consensus protocol improving liveness and efficiency                   | Standards | Core      | Proposed |
+| 2  | [Starfish Consensus Protocol](iips/IIP-0002/iip-0002.md) | A DAG-based consensus protocol improving liveness and efficiency                   | Standards | Core      | Active   |
 | 3  | [Sequencer Improvements](iips/IIP-0003/iip-0003.md)      | Improved sequencing algorithm for reducing the number of transaction cancellations | Standards | Core      | Active   |
 | 5  | [Move View Functions](iips/IIP-0005/iip-0005.md)         | A standardized interface for application-specific queries to on-chain state        | Standards | Interface | Draft    |
 | 7  | [Validator Scoring Mechanism](iips/IIP-0007/IIP-0007.md) | An automated and standardized system for monitoring validator behavior and scores  | Standards | Core      | Draft    |

--- a/iips/IIP-0002/iip-0002.md
+++ b/iips/IIP-0002/iip-0002.md
@@ -4,7 +4,7 @@ title: Starfish Consensus Protocol
 description: A DAG-based consensus protocol improving liveness and efficiency
 author: Nikita Polianskii (@polinikita) <nikita.polianskii@iota.org>
 discussions-to: https://github.com/iotaledger/IIPs/discussions/10
-status: Proposed
+status: Active
 type: Standards Track
 layer: Core
 created: 2025-04-16


### PR DESCRIPTION
Starfish Consensus Protocol is enabled on IOTA Mainnet, so IIP-2 transitions from `Proposed` to `Active` per the status definitions in the README.

Changes:
- `iips/IIP-0002/iip-0002.md`: front-matter `status: Proposed` → `status: Active`.
- `README.md`: status column for IIP-2 updated, and "Last updated" bumped.